### PR TITLE
[VCS Sync] 1 rule change(s) from space dev (vcs-sync-20260714-004859)

### DIFF
--- a/.vcs-sync/vcs-sync-20260714-004859.json
+++ b/.vcs-sync/vcs-sync-20260714-004859.json
@@ -1,0 +1,1 @@
+{"requested_at":"2026-07-14T00:48:59Z","dev_space":"dev","sync_tag":"vcs","branch":"vcs-sync-20260714-004859","workflow_execution_id":"6f1b3c50-89ff-4831-b991-79ea7c5acc47","changed_rule_ids":["6959fe35-b928-47e0-b76f-8feb609158c8"]}

--- a/dac-vcs-rules/rules/test_custom_rule_for_workflow.toml
+++ b/dac-vcs-rules/rules/test_custom_rule_for_workflow.toml
@@ -1,0 +1,54 @@
+[metadata]
+creation_date = "2026/07/14"
+integration = []
+maturity = "development"
+updated_date = "2026/07/14"
+
+[rule]
+actions = []
+author = ["3610252053"]
+description = "Test custom rule for workflow"
+enabled = false
+exceptions_list = []
+false_positives = []
+filters = []
+from = "now-6m"
+index = [
+    "apm-*-transaction*",
+    "auditbeat-*",
+    "endgame-*",
+    "filebeat-*",
+    "logs-*",
+    "packetbeat-*",
+    "traces-apm*",
+    "winlogbeat-*",
+    "-*elastic-cloud-logs-*",
+]
+interval = "5m"
+language = "kuery"
+license = ""
+max_signals = 100
+name = "Test custom rule for workflow"
+references = []
+related_integrations = []
+required_fields = []
+risk_score = 21
+risk_score_mapping = []
+rule_id = "6959fe35-b928-47e0-b76f-8feb609158c8"
+setup = ""
+severity = "low"
+severity_mapping = []
+tags = ["vcs"]
+threat = []
+to = "now"
+type = "query"
+
+query = '''
+event.category:"process" and process.name:"whoami"
+'''
+
+
+
+[rule.meta]
+kibana_siem_app_url = "https://dac-workflow-dev-5350f4.kb.us-central1.gcp.cloud.es.io/s/dev/app/security"
+


### PR DESCRIPTION
Automated Detection-as-Code sync opened by the Elastic workflow **DaC - VCS Rule Sync** (execution `6f1b3c50-89ff-4831-b991-79ea7c5acc47`).

Rules tagged `vcs` in the "dev" Kibana space changed since the last sync. The **DaC - VCS rule sync** GitHub Action now exports the tagged rules into this branch (detection-rules `kibana export-rules -e -ac`; existing files are overwritten so edits are included), commits them, runs the detection-rules unit tests, and comments the results here.

Changed rule(s):
- Test custom rule for workflow (`6959fe35-b928-47e0-b76f-8feb609158c8`)

Merging this PR accepts the rule state into version control. If the export produces no changes, the Action closes this PR automatically.
